### PR TITLE
Enpoints for devices and time slots

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -139,3 +139,11 @@ class TimeSlotSerializer(serializers.ModelSerializer):
         if data['start_timestamp'] >= data['end_timestamp']:
             raise serializers.ValidationError("Start time must be before end time.")
         return data
+
+
+class DeviceWithTimeSlotsSerializer(serializers.ModelSerializer):
+    timeSlots = TimeSlotSerializer(source='timeslot_set', many=True)
+
+    class Meta:
+        model = Device
+        fields = ['id', 'name', 'device_type', 'timeSlots']

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     path("api/devices/all/", views.DeviceListAllView.as_view(), name="device_list_all"),
     path("api/devices/<int:device_id>/time-slots/all/", views.TimeSlotListView.as_view(), name="time_slot_list_all"),
     path("api/devices/<int:device_id>/time-slots/add/", views.TimeSlotCreateView.as_view(), name="time_slot_create"),
+    path("api/devices/brewery/<int:brewery_id>/with-time-slots/", views.DevicesWithTimeSlotsView.as_view(), name="time_slot_list_brewery"),
 ]


### PR DESCRIPTION
Added several enpoints. All of them are protected, in order to access them, a header should be defined:
```
Authorization: Bearer <ACCESS_TOKEN>
```

## `api/devices/add/`
**POST**, example of body of the request:
```
{
  "name": "Brewery Device 1",
  "device_type": "FT",
  "serial_number": "123456789",
  "capacity": "100",
  "temperature_min": "10",
  "temperature_max": "20",
  "sour_beers": true,
  "carbonation": "High",
  "supported_containers": "Bottles"
}
```

Possible responses:
```
{
    "message": "Device successfully created.",
    "id": 1
}
```
```
{
    "error": "Unauthorized to add devices for this brewery."
}
```

## `api/devices/brewery/X/`
**GET**, `X` is brewery ID.
Possible responses:
```
[
    {
        "id": 1,
        "name": "Brewery Device 1",
        "device_type": "FT",
        "serial_number": "123456789",
        "capacity": 100.0,
        "temperature_min": 10.0,
        "temperature_max": 20.0,
        "sour_beers": true,
        "carbonation": "High",
        "supported_containers": "Bottles",
        "commercial_brewery": 2
    }
]
```

```
{
    "error": "Unauthorized to view devices for this brewery."
}
```

## `api/devices/all/`
**GET**
```
[
    {
        "id": 1,
        "name": "Brewery Device 1",
        "device_type": "FT",
        "serial_number": "123456789",
        "capacity": 100.0,
        "temperature_min": 10.0,
        "temperature_max": 20.0,
        "sour_beers": true,
        "carbonation": "High",
        "supported_containers": "Bottles",
        "commercial_brewery": 2
    }
]
```
```
{
    "error": "Unauthorized to view all devices."
}
```


## `api/devices/X/time-slots/add/`
**POST**, `X` is device ID, example of body of the request:
```
{
  "status": "F",
  "slot_type": "H",
  "price": 150.00,
  "start_timestamp": "2024-12-20T10:00:00Z",
  "end_timestamp": "2024-12-20T12:00:00Z",
  "device": 1
}
```
Possible responses:
```
{
    "message": "Time slot successfully created.",
    "id": 3
}
```
```
{
    "error": "Unauthorized to add time slots for this device."
}
```
```
{
    "error": "Unauthorized to add time slots for this user."
}
```

## `api/devices/X/time-slots/all/`
**GET**, `X` is device ID.
Possible responses:
```
[
    {
        "id": 1,
        "status": "F",
        "slot_type": "H",
        "price": "150.00",
        "start_timestamp": "2024-12-20T11:00:00+01:00",
        "end_timestamp": "2024-12-20T13:00:00+01:00",
        "device": 1,
        "order": null
    }
]
```
```
{
    "error": "Unauthorized to view time slots for this device."
}
```
